### PR TITLE
Fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kieranb662/CGExtender.git", from: "1.0.1"),
-        .package(url: "https://github.com/kieranb662/Shapes.git", from: "1.0.2"),
+        .package(name: "Shapes", url: "https://github.com/kieranb662/SwiftUI-Shapes.git", from: "1.0.2"),
         .package(url: "https://github.com/kieranb662/bez.git", from: "1.0.0")
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),


### PR DESCRIPTION
I would like to use your package, but I could not import it because there was no package whose url was `https://github.com/kieranb662/Shapes.git`.
To work around this, I changed package url and rename it in Package.swift.
I don't know whether it is correct, so please review my PR before marging.
Thanks.